### PR TITLE
Mac universal build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,3 +102,12 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: npm run dist -- --publish=always
+
+      - name: Verify mac universal and notarization
+        if: matrix.os == 'macos-latest'
+        run: |
+          hdiutil attach -quiet -mountpoint /Volumes/SonacoveMeets "dist/Sonacove Meets.dmg"
+          file "/Volumes/SonacoveMeets/Sonacove Meets.app/Contents/MacOS/Sonacove Meets"
+          codesign --verify --deep --strict "/Volumes/SonacoveMeets/Sonacove Meets.app"
+          spctl --assess --type execute --verbose "/Volumes/SonacoveMeets/Sonacove Meets.app" || true
+          hdiutil detach -quiet /Volumes/SonacoveMeets

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
       "hardenedRuntime": true,
       "entitlements": "resources/entitlements.mac.plist",
       "artifactName": "${productName}.${ext}",
+      "universalApp": true,
+      "target": [ "dmg", "zip" ],
       "extendInfo": {
         "NSCameraUsageDescription": "Sonacove requires access to your camera for meetings.",
         "NSMicrophoneUsageDescription": "Sonacove requires access to your microphone for meetings.",


### PR DESCRIPTION
- Makes the mac app universal (Intel + Apple Silicon).
- Adds a simple CI step on macOS to mount the DMG and verify architectures, codesign, and Gatekeeper acceptance.

This should fix the issue with the app not being supported on older Macs.