### PR TITLE
feat(webrtc): enable FlexFEC video FEC for P2P calls

### DIFF
--- a/main.js
+++ b/main.js
@@ -99,8 +99,14 @@ if (isDev) {
     app.commandLine.appendSwitch('allow-insecure-localhost');
 }
 
-// Enable Opus RED field trial.
-app.commandLine.appendSwitch('force-fieldtrials', 'WebRTC-Audio-Red-For-Opus/Enabled/');
+// Enable WebRTC field trials:
+// - Opus RED: redundant audio encoding for packet loss resilience
+// - FlexFEC-03: forward error correction for video in P2P calls
+//   (advertise in SDP + enable sending; receive is on by default)
+app.commandLine.appendSwitch('force-fieldtrials',
+    'WebRTC-Audio-Red-For-Opus/Enabled/'
+    + 'WebRTC-FlexFEC-03-Advertised/Enabled/'
+    + 'WebRTC-FlexFEC-03/Enabled/');
 
 // Wayland: Enable optional PipeWire support.
 if (!app.commandLine.hasSwitch('enable-features')) {


### PR DESCRIPTION
## Summary
- Enable `WebRTC-FlexFEC-03-Advertised` and `WebRTC-FlexFEC-03` field trials in Electron's Chromium
- Provides forward error correction for video in P2P calls — recovers lost packets without NACK round-trips
- ~50-200ms faster recovery per lost packet compared to NACK/RTX retransmission
- No server-side changes needed — FlexFEC works end-to-end in P2P (no SFU in the path)
- lib-jitsi-meet already allows `flexfec-03` through its P2P codec filter (only strips ULPFEC/RED)

## Test plan
- [ ] P2P call in Electron → verify `flexfec-03` appears in SDP offer/answer (`chrome://webrtc-internals`)
- [ ] Simulate 5% packet loss with DevTools → compare video quality with/without FlexFEC
- [ ] Verify no impact on JVB (multi-party) calls — FlexFEC not advertised for JVB sessions since lib-jitsi-meet strips it