### PR TITLE
fix(deeplink): route dialog to main window, not annotation overlay

### DIFF
--- a/app/features/sonacove/deep-link.js
+++ b/app/features/sonacove/deep-link.js
@@ -1,26 +1,12 @@
-const { app, BrowserWindow } = require('electron');
+const { app } = require('electron');
 const path = require('path');
 
 const sonacoveConfig = require('./config');
 const { showDeeplinkModal } = require('./in-app-dialogs');
-const { closeOverlay, getOverlayWindow } = require('./overlay-window');
+const { closeOverlay, getMainWindow } = require('./overlay-window');
 
 let pendingDeepLinkUrl = null;
 let navigatingDeepLink = false;
-
-/**
- * Finds the main visible application window to receive deep link events.
- *
- * @returns {BrowserWindow|undefined} The main visible window.
- */
-function getMainWindow() {
-    const overlay = getOverlayWindow();
-    const windows = BrowserWindow.getAllWindows();
-
-    // Exclude the annotation overlay (fullscreen, transparent) and small windows (PiP).
-    return windows.find(w =>
-        !w.isDestroyed() && w.isVisible() && w !== overlay && w.getBounds().width >= 600);
-}
 
 /**
  * Registers the custom protocol scheme for the application.

--- a/app/features/sonacove/overlay-window.js
+++ b/app/features/sonacove/overlay-window.js
@@ -12,7 +12,11 @@ let pendingNotify = true;
  * @returns {BrowserWindow|undefined} The main window instance.
  */
 function getMainWindow() {
-    return BrowserWindow.getAllWindows().find(w => !w.isDestroyed() && w.getTitle() === 'Sonacove Meets');
+    const windows = BrowserWindow.getAllWindows();
+
+    // Exclude the annotation overlay (fullscreen, transparent) and small windows (PiP).
+    return windows.find(w =>
+        !w.isDestroyed() && w.isVisible() && w !== annotationWindow && w.getBounds().width >= 600);
 }
 
 /**
@@ -341,7 +345,8 @@ function restoreMainWindow() {
     }
 }
 
-module.exports = { toggleOverlay,
+module.exports = { getMainWindow,
+    toggleOverlay,
     closeOverlay,
     getOverlayWindow,
     closeViewersWhiteboards };


### PR DESCRIPTION
## Summary
- `getMainWindow()` in `deep-link.js` used a size heuristic (`width >= 600`) to find the main window, but the fullscreen annotation overlay also matched
- When a deeplink arrived during an active annotation session, the "leave meeting?" modal was injected into the overlay's webContents — invisible and unclickable, locking the user
- Fix: explicitly exclude the overlay window via `getOverlayWindow()` reference comparison

## Test plan
- [ ] Start a meeting and open annotation overlay
- [ ] Open a meeting link in the browser that triggers the `sonacove://` deeplink
- [ ] Verify the "leave meeting?" dialog appears on the main app window, not the overlay
- [ ] Verify clicking "Leave Meeting" navigates to the new meeting correctly
- [ ] Verify clicking "Stay" dismisses the dialog and keeps the current meeting