### PR TITLE
fix(audio): add setDisplayMediaRequestHandler for echo-free system audio

### DIFF
--- a/app/preload/preload.js
+++ b/app/preload/preload.js
@@ -30,7 +30,9 @@ const whitelistedIpcChannels = [
     'posthog-capture',
     'retry-load',
     'update-toast-action',
-    'leave-modal-action'
+    'leave-modal-action',
+    'display-media-request',
+    'display-media-response'
 ];
 
 // Unlimited listeners — the preload subscribes to many channels across the app
@@ -105,6 +107,9 @@ window.sonacoveElectronAPI = {
     captureScreenshot: () => ipcRenderer.invoke('capture-screenshot'),
     saveScreenshot: (base64Data, filename) => ipcRenderer.invoke('save-screenshot', base64Data, filename),
     showInFolder: filePath => ipcRenderer.send('show-in-folder', filePath),
+    respondToDisplayMedia: data => {
+        ipcRenderer.send('display-media-response', data);
+    },
     ipc: {
         on: (channel, listener) => {
             if (!whitelistedIpcChannels.includes(channel)) {
@@ -152,6 +157,18 @@ window.sonacoveElectronAPI = {
         }
     }
 };
+
+// ── getDisplayMedia bridge ──────────────────────────────────────────────
+// When the main process intercepts a getDisplayMedia call (via
+// setDisplayMediaRequestHandler), it sends available sources here.
+// We dispatch a CustomEvent so the web app (conference.js) can show its
+// DesktopPicker dialog. Once the user selects a source, the web app calls
+// sonacoveElectronAPI.respondToDisplayMedia() to send the choice back.
+ipcRenderer.on('display-media-request', (_, sources) => {
+    window.dispatchEvent(
+        new CustomEvent('electron-display-media-request', { detail: { sources } })
+    );
+});
 
 window.JitsiMeetElectron = {
     /**

--- a/main.js
+++ b/main.js
@@ -542,6 +542,67 @@ function createJitsiMeetWindow() {
         }
     }
 
+    // ── Screen Sharing via getDisplayMedia ────────────────────────────────
+    // Setting this handler enables navigator.mediaDevices.getDisplayMedia() in the renderer.
+    // Without it, getDisplayMedia fails and lib-jitsi-meet falls back to the legacy
+    // getUserMedia({ chromeMediaSource: 'desktop' }) path which can't use restrictOwnAudio.
+    //
+    // With this handler + restrictOwnAudio constraint, system audio loopback excludes
+    // the Electron app's own audio output — so teachers can share YouTube audio without
+    // echoing meeting voices back to everyone.
+    mainWindow.webContents.session.setDisplayMediaRequestHandler(async (request, callback) => {
+        try {
+            const sources = await desktopCapturer.getSources({
+                types: [ 'screen', 'window' ],
+                thumbnailSize: { width: 300,
+                    height: 300 },
+                fetchWindowIcons: true
+            });
+
+            const mappedSources = sources.map(source => ({
+                id: source.id,
+                name: source.name,
+                thumbnail: { dataUrl: source.thumbnail.toDataURL() }
+            }));
+
+            // Ask the renderer to show our custom DesktopPicker dialog
+            mainWindow.webContents.send('display-media-request', mappedSources);
+
+            // Wait for the user's selection
+            const result = await new Promise(resolve => {
+                ipcMain.once('display-media-response', (_, data) => resolve(data));
+            });
+
+            if (!result?.sourceId) {
+                callback(); // User cancelled
+
+                return;
+            }
+
+            const source = sources.find(s => s.id === result.sourceId);
+
+            if (!source) {
+                callback();
+
+                return;
+            }
+
+            const streams = { video: source };
+
+            // System audio loopback only works for screen sources (not individual windows).
+            // The restrictOwnAudio constraint (in getDisplayMedia) tells Chromium to exclude
+            // this app's audio from the loopback capture.
+            if (result.shareAudio && source.id.startsWith('screen:')) {
+                streams.audio = 'loopback';
+            }
+
+            callback(streams);
+        } catch (err) {
+            console.error('Display media handler error:', err);
+            callback();
+        }
+    });
+
     // Prevent Close during Meeting — show custom in-app modal instead of native dialog.
     // Not calling event.preventDefault() keeps the page open (prevents unload).
     // If the user confirms "Leave", the IPC handler calls mainWindow.destroy().

--- a/main.js
+++ b/main.js
@@ -568,9 +568,17 @@ function createJitsiMeetWindow() {
             // Ask the renderer to show our custom DesktopPicker dialog
             mainWindow.webContents.send('display-media-request', mappedSources);
 
-            // Wait for the user's selection
+            // Wait for the user's selection (60s timeout to prevent hanging if picker is dismissed)
             const result = await new Promise(resolve => {
-                ipcMain.once('display-media-response', (_, data) => resolve(data));
+                const timeout = setTimeout(() => {
+                    ipcMain.removeAllListeners('display-media-response');
+                    resolve(null);
+                }, 60000);
+
+                ipcMain.once('display-media-response', (_, data) => {
+                    clearTimeout(timeout);
+                    resolve(data);
+                });
             });
 
             if (!result?.sourceId) {


### PR DESCRIPTION
## Summary
- Add `setDisplayMediaRequestHandler` to enable `getDisplayMedia` in Electron
- Bridge the handler to our existing DesktopPicker dialog via IPC
- Add `display-media-request`/`display-media-response` IPC channels in preload
- Add `respondToDisplayMedia()` method to `sonacoveElectronAPI`

## Context
When screen sharing with "Share system audio" checked, the legacy `getUserMedia({ chromeMediaSource: 'desktop' })` path captures ALL system audio including meeting voices, causing severe echo feedback for everyone.

With `setDisplayMediaRequestHandler`, `getDisplayMedia` now works in Electron, enabling the `restrictOwnAudio` constraint (Chrome 141+, Electron 40 = Chromium ~144). This tells Chromium to exclude the Electron app's own audio output from the system audio loopback — so teachers can share YouTube audio without echoing meeting voices.

### IPC flow
```
Web calls getDisplayMedia(constraints)  [constraints include restrictOwnAudio: true]
  → Electron intercepts via setDisplayMediaRequestHandler
  → Main gets sources via desktopCapturer.getSources()
  → Main sends 'display-media-request' IPC to renderer
  → Preload dispatches CustomEvent → web app shows DesktopPicker
  → User selects source + audio option
  → Web calls respondToDisplayMedia() → 'display-media-response' IPC to main
  → Main calls handler callback with { video: source, audio: 'loopback' }
  → getDisplayMedia resolves (restrictOwnAudio applied by Chromium)
```

## Companion PRs
- **jitsi-meet** alfaz-studio/jitsi-meet#423: Lower opus bitrate + add display media bridge in `conference.js`
- **lib-jitsi-meet** alfaz-studio/lib-jitsi-meet#13: Remove Electron exclusion from `restrictOwnAudio` check

## Test plan
- [ ] Screen share + "Share system audio" → YouTube audible, no meeting echo
- [ ] Screen share without audio → works as before
- [ ] Window sharing → works (no audio option for windows)
- [ ] Cancel picker → no crash, screen share cancelled gracefully