### PR TITLE
fix: graceful meeting leave on Electron window close

### DIFF
--- a/main.js
+++ b/main.js
@@ -591,10 +591,23 @@ function createJitsiMeetWindow() {
         });
     });
 
+    let quitting = false;
+
     const onLeaveModal = (event, data) => {
         if (event.sender !== mainWindow?.webContents) return;
         if (data && data.action === 'confirm' && mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.destroy();
+            // Trigger the same leaveConference() flow the PiP hangup button uses.
+            // The renderer handles the clean XMPP leave, then navigates to
+            // /static/close — the will-navigate handler sees `quitting` and
+            // destroys the window instead of loading the dashboard.
+            quitting = true;
+            mainWindow.webContents.send('pip-end-meeting');
+
+            // Fallback: if the leave flow never triggers navigation (e.g. page
+            // is unresponsive or not in a meeting), destroy after 5s.
+            setTimeout(() => {
+                if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
+            }, 5000);
         }
     };
 
@@ -728,6 +741,17 @@ function createJitsiMeetWindow() {
             if (event) {
                 event.preventDefault();
             }
+
+            // If the user confirmed the leave-modal, destroy instead of
+            // navigating to the dashboard — the meeting was left cleanly.
+            if (quitting) {
+                setImmediate(() => {
+                    if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
+                });
+
+                return 'destroyed';
+            }
+
             const landingUrl = new URL(config.currentConfig.landing);
 
             // Remove trailing slash if present on landing pathname

--- a/main.js
+++ b/main.js
@@ -713,8 +713,6 @@ function createJitsiMeetWindow() {
         try {
             const sources = await desktopCapturer.getSources(validOptions);
 
-            console.log(`✅ Main: Found ${sources.length} sources`);
-
             const mappedSources = sources.map(source => {
                 return {
                     id: source.id,

--- a/main.js
+++ b/main.js
@@ -581,7 +581,8 @@ function createJitsiMeetWindow() {
 
     // Prevent Close during Meeting — show custom in-app modal instead of native dialog.
     // Not calling event.preventDefault() keeps the page open (prevents unload).
-    // If the user confirms "Leave", the IPC handler calls mainWindow.destroy().
+    // If the user confirms "Leave", the IPC handler triggers a clean XMPP leave
+    // via pip-end-meeting, then the will-navigate handler destroys the window.
     mainWindow.webContents.on('will-prevent-unload', () => {
         showLeaveModal(mainWindow.webContents, {
             title: t('leaveModal.title'),
@@ -592,6 +593,7 @@ function createJitsiMeetWindow() {
     });
 
     let quitting = false;
+    let quitFallbackTimer = null;
 
     const onLeaveModal = (event, data) => {
         if (event.sender !== mainWindow?.webContents) return;
@@ -605,7 +607,7 @@ function createJitsiMeetWindow() {
 
             // Fallback: if the leave flow never triggers navigation (e.g. page
             // is unresponsive or not in a meeting), destroy after 5s.
-            setTimeout(() => {
+            quitFallbackTimer = setTimeout(() => {
                 if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
             }, 5000);
         }
@@ -743,11 +745,12 @@ function createJitsiMeetWindow() {
             // If the user confirmed the leave-modal, destroy instead of
             // navigating to the dashboard — the meeting was left cleanly.
             if (quitting) {
+                clearTimeout(quitFallbackTimer);
                 setImmediate(() => {
                     if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
                 });
 
-                return 'destroyed';
+                return;
             }
 
             const landingUrl = new URL(config.currentConfig.landing);
@@ -1027,11 +1030,12 @@ function createJitsiMeetWindow() {
     ipcMain.on('retry-load', onRetryLoad);
 
     mainWindow.on('closed', () => {
-        // Cancel any pending blur timer.
+        // Cancel any pending timers.
         if (blurTimer) {
             clearTimeout(blurTimer);
             blurTimer = null;
         }
+        clearTimeout(quitFallbackTimer);
 
         // Remove PiP IPC listeners to prevent accumulation on window recreation (macOS).
         cleanupPip();


### PR DESCRIPTION
## Summary

- When the user closes the Electron window during a meeting, the app now triggers a clean `leaveConference()` flow instead of immediately destroying the window
- Reuses the same `pip-end-meeting` IPC channel that the PiP hangup button uses — the renderer handles the XMPP leave, so other participants see the user disappear immediately
- Previously, `mainWindow.destroy()` killed the page without sending an XMPP leave stanza, causing the user to remain visible for 30-60s until the server timeout

## Changes

- `onLeaveModal`: sends `pip-end-meeting` IPC to renderer instead of calling `mainWindow.destroy()`
- `will-navigate` handler: destroys window on `/static/close` redirect when `quitting` flag is set
- 5s fallback timer ensures window is destroyed if the leave flow hangs

Closes #118

## Test plan

- [ ] Join a meeting with 2+ users
- [ ] Close the Electron window (X / Alt+F4) while in the meeting
- [ ] Confirm leave in the modal
- [ ] Verify the user disappears immediately for other participants
- [ ] Verify the Electron app quits after leaving
- [ ] Verify normal "Leave meeting" button still works as before
- [ ] Verify PiP hangup button still works as before