### PR TITLE
fix: macOS single instance lock and child window handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -1046,21 +1046,25 @@ function createJitsiMeetWindow() {
     handleProtocolCall(process.argv.pop());
 }
 
-// Handle PiP and child window icon configuration
+// Set the app icon on child windows opened via window.open().
+// Only applies to windows from the main window's renderer — child
+// windows (PiP, WebRTC internals) don't need this handler.
 const setupChildWindowIcon = () => {
     const iconPath = getIconPath();
 
-    // Listen for all new BrowserWindow creations
     app.on('web-contents-created', (event, contents) => {
-        // This handles windows opened via window.open()
+        // Skip the main window — it has its own windowOpenHandler that
+        // decides allow/deny. Only override icon on child windows that
+        // are already allowed to open (e.g. PiP panel, allowed-host popups).
+        if (!contents.opener) return;
+
         contents.setWindowOpenHandler(({ url }) => {
-            return {
-                action: 'allow',
-                overrideBrowserWindowOptions: {
-                    icon: iconPath,
-                    show: true
-                }
-            };
+            // Child windows should open links in the external browser,
+            // not spawn another Electron window (e.g. "Go to Dashboard"
+            // on the close page).
+            openExternalLink(url);
+
+            return { action: 'deny' };
         });
     });
 };
@@ -1112,9 +1116,10 @@ function handleProtocolCall(fullProtocolCall) {
 
 /**
  * Force Single Instance Application.
- * Handle this on darwin via LSMultipleInstancesProhibited in Info.plist as below does not work on MAS
+ * MAS builds use LSMultipleInstancesProhibited in Info.plist instead,
+ * since requestSingleInstanceLock() is unreliable in the MAS sandbox.
  */
-const gotInstanceLock = process.platform === 'darwin' ? true : app.requestSingleInstanceLock();
+const gotInstanceLock = process.mas ? true : app.requestSingleInstanceLock();
 
 if (!gotInstanceLock) {
     app.quit();


### PR DESCRIPTION
## Summary

**None of these issues were reproducible on Windows — they are likely macOS-only.**

- **#103 — Multiple windows opening**: Enable `requestSingleInstanceLock()` on macOS (non-MAS). Previously skipped for all darwin, which allowed multiple instances to spawn when deep links fired during crashes. MAS builds still use `LSMultipleInstancesProhibited` in Info.plist.
- **#117 — Links opening in small windows**: Fix `setupChildWindowIcon` to not blindly allow all `window.open()` calls from child windows. Links now open in the external browser instead of spawning tiny Electron windows.

Closes #103
Closes #117

**Note:** #115 (leave meeting dialog doesn't work) is not addressed here — unable to reproduce on Windows, needs more details from the reporter to identify the root cause.

## Test plan

### #103 — Multiple windows
1. Launch the app and join a meeting
2. Open the browser console in the Electron window (View → Toggle DevTools or Cmd+Option+I)
3. Simulate a crash by running:
   ```js
   APP.connection.xmpp.connection.disconnect()
   ```
4. While disconnected, trigger a deep link (e.g. click a `sonacove://` meeting link)
5. **Before fix:** a second window opens. **After fix:** the existing window is focused and reused.

### #117 — Links opening in small windows
1. Join a meeting, then leave via the hangup button
2. On the close page, click "Go to Dashboard"
3. **Before fix:** opens in a tiny Electron window. **After fix:** opens in the external browser (or navigates in the same window).

### General
- [ ] PiP window still works as expected
- [ ] Allowed-host popups (e.g. Paddle checkout) still open inside Electron
- [ ] Windows behavior is unchanged