### PR TITLE
fix(pip): keep dock icon visible, close PiP on open window click

### DIFF
--- a/app/features/pip/participant-panel-preload.js
+++ b/app/features/pip/participant-panel-preload.js
@@ -9,6 +9,8 @@ const { contextBridge, ipcRenderer } = require('electron');
  *   - Toggle between horizontal and vertical strip layouts.
  *   - Receive the current orientation from the main process.
  */
+contextBridge.exposeInMainWorld('panelPlatform', process.platform);
+
 contextBridge.exposeInMainWorld('panelAPI', {
     /**
      * Register a callback that fires whenever a new video frame arrives.

--- a/app/features/pip/participant-panel.css
+++ b/app/features/pip/participant-panel.css
@@ -419,6 +419,12 @@ html, body {
   position: relative;
 }
 
+/* macOS shows a rounded-square window background behind transparent windows;
+   match the pill shape to that native corner radius so there's no gap. */
+.pill-btn.macos {
+  border-radius: 12px;
+}
+
 .pill-btn.visible {
   opacity: 1;
   transform: scale(1);

--- a/app/features/pip/participant-panel.html
+++ b/app/features/pip/participant-panel.html
@@ -99,6 +99,11 @@
       var pillBadge = document.getElementById('pillBadge');
       var chatBadgeCount = document.getElementById('chatBadgeCount');
 
+      // macOS: match pill shape to the native rounded-square window background.
+      if (window.panelPlatform === 'darwin') {
+        pillBtn.classList.add('macos');
+      }
+
       // ── Tile rendering ─────────────────────────────────────────────────────
 
       function getVisibleParticipants() {

--- a/app/features/pip/participant-window.js
+++ b/app/features/pip/participant-window.js
@@ -147,6 +147,11 @@ ipcMain.on(IPC.FOCUS_MAIN, () => {
         mw.show();
         mw.focus();
     }
+
+    // Close PiP directly instead of relying on the indirect
+    // pip-window-restored → renderer → shrinkToPill path,
+    // which races with the blur timer on macOS.
+    closeParticipantWindow(false);
 });
 
 // ── Window lifecycle ─────────────────────────────────────────────────────────
@@ -240,6 +245,12 @@ function openParticipantWindow() {
             }
 
             participantWindow.show();
+
+            // macOS: PiP has skipTaskbar+alwaysOnTop, so macOS hides
+            // the dock icon when it's the only visible window.
+            if (process.platform === 'darwin') {
+                app.dock.show();
+            }
         }
     });
 


### PR DESCRIPTION
Fixes #121 (macOS-only issues: dock visibility, "open window" button, pill shape)

## Summary
- macOS dock icon stays visible when PiP is the only on-screen window (`app.dock.show()` after PiP opens)
- "Open window" button now closes PiP directly instead of relying on the indirect `pip-window-restored` → renderer → `shrinkToPill` path, which raced with the blur timer causing intermittent failures
- Clicking "Open window" now closes PiP (as requested in the issue)
- Pill button uses rounded-square shape (12px radius) on macOS to match the native transparent window background, instead of a circle with visible square corners behind it

## Test plan (macOS only)
- [x] Open a meeting, minimize the main window so PiP appears → **dock icon stays visible**
- [x] Click "Open window" in PiP → **main window restores AND PiP closes**
- [x] Repeat "Open window" click rapidly → no crash, no stale PiP window
- [x] Minimize main window → PiP opens → alt-tab back to main window → no flicker or race
- [x] Shrink PiP to pill → **pill is rounded-square, no visible square background behind it**
- [x] Click pill to expand → click "Open window" → clean transition
- [ ] On Windows/Linux, pill should still be circular (no `.macos` class applied)