### PR TITLE
fix(pip): participant count, toggle icons, button order, restore behavior

### DIFF
--- a/app/features/ipc.js
+++ b/app/features/ipc.js
@@ -173,8 +173,14 @@ function setupSonacoveIPC(ipcMain, mainWindow, handlers = {}) {
 
     // Renderer signals the main window was restored — close the PiP entirely.
     // The pill is only entered via the explicit "Minimize to pill" button.
+    // Guard: if shrinkToPill() just fired, the renderer sends pip-screenshare-stop
+    // in response to pip-panel-closed — don't destroy the window in that case.
     register('pip-screenshare-stop', () => {
-        closeParticipantWindow();
+        const { isPillMode } = require('./pip/pill');
+
+        if (!isPillMode()) {
+            closeParticipantWindow();
+        }
     });
 
     // User toggled pin state in the PiP panel — forward to main renderer

--- a/app/features/ipc.js
+++ b/app/features/ipc.js
@@ -171,8 +171,9 @@ function setupSonacoveIPC(ipcMain, mainWindow, handlers = {}) {
         sendParticipantsUpdate(participants);
     });
 
-    // Renderer signals the main window was restored — close the PiP entirely.
-    // The pill is only entered via the explicit "Minimize to pill" button.
+    // Renderer signals screenshare stopped (main window restored, or panel
+    // closed notification echoed back). Only close the PiP if we're not
+    // already in pill mode — shrinkToPill() triggers this same event.
     // Guard: if shrinkToPill() just fired, the renderer sends pip-screenshare-stop
     // in response to pip-panel-closed — don't destroy the window in that case.
     register('pip-screenshare-stop', () => {

--- a/app/features/ipc.js
+++ b/app/features/ipc.js
@@ -171,17 +171,10 @@ function setupSonacoveIPC(ipcMain, mainWindow, handlers = {}) {
         sendParticipantsUpdate(participants);
     });
 
-    // Renderer signals screenshare ended — shrink to pill instead of
-    // destroying the window, so the user can reopen it without re-minimizing.
-    // shrinkToPill() has an internal null-window guard, so this is safe even
-    // if the PiP window was never opened or creation failed.
+    // Renderer signals the main window was restored — close the PiP entirely.
+    // The pill is only entered via the explicit "Minimize to pill" button.
     register('pip-screenshare-stop', () => {
-        // Lazy require — pill.js only needed here.
-        const { isPillMode } = require('./pip/pill');
-
-        if (!isPillMode()) {
-            shrinkToPill();
-        }
+        closeParticipantWindow();
     });
 
     // User toggled pin state in the PiP panel — forward to main renderer

--- a/app/features/pip/participant-panel.html
+++ b/app/features/pip/participant-panel.html
@@ -28,7 +28,7 @@
       <div class="control-right">
         <button class="ctrl-btn" id="toggleBtn" title="Toggle layout">
           <span id="toggleIcon">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M12 3v18"/></svg>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 16-4 4-4-4"/><path d="M17 20V4"/><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/></svg>
           </span>
         </button>
         <button class="ctrl-btn" id="chatBtn" title="Open chat" style="position: relative;">
@@ -61,8 +61,8 @@
       // ── Icons ──────────────────────────────────────────────────────────────
 
       var GRIP_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="5" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="19" cy="5" r="1"/><circle cx="5" cy="12" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="19" r="1"/><circle cx="12" cy="19" r="1"/><circle cx="19" cy="19" r="1"/></svg>';
-      var TOGGLE_COLUMNS = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M12 3v18"/></svg>';
-      var TOGGLE_ROWS = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 12h18"/></svg>';
+      var TOGGLE_COLUMNS = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 16-4 4-4-4"/><path d="M17 20V4"/><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/></svg>';
+      var TOGGLE_ROWS = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3 4 7l4 4"/><path d="M4 7h16"/><path d="m16 21 4-4-4-4"/><path d="M20 17H4"/></svg>';
       var USER_FALLBACK = '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>';
       var MIC_ON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.7)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" x2="12" y1="19" y2="22"/></svg>';
       var MIC_OFF = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#FF6B6B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="2" x2="22" y1="2" y2="22"/><path d="M18.89 13.23A7.12 7.12 0 0 0 19 12v-2"/><path d="M5 10v2a7 7 0 0 0 12 5"/><path d="M15 9.34V5a3 3 0 0 0-5.68-1.33"/><path d="M9 9v3a3 3 0 0 0 5.12 2.12"/><line x1="12" x2="12" y1="19" y2="22"/></svg>';
@@ -366,10 +366,10 @@
         gripIcon.innerHTML = GRIP_ICON;
 
         if (currentOrientation === 'horizontal') {
-          toggleIcon.innerHTML = TOGGLE_ROWS;
+          toggleIcon.innerHTML = TOGGLE_COLUMNS;
           document.getElementById('toggleBtn').title = 'Switch to vertical layout';
         } else {
-          toggleIcon.innerHTML = TOGGLE_COLUMNS;
+          toggleIcon.innerHTML = TOGGLE_ROWS;
           document.getElementById('toggleBtn').title = 'Switch to horizontal layout';
         }
       }

--- a/app/features/pip/participant-panel.html
+++ b/app/features/pip/participant-panel.html
@@ -75,6 +75,7 @@
 
       var currentOrientation = 'horizontal';
       var participants = [];
+      var totalParticipantCount = 0;
       var visibleTileCount = 4;
       var resizeEdge = null; // which edge is being dragged — determines slice direction
       // { participantId: true } — local pinned by default.
@@ -374,8 +375,8 @@
       }
 
       function updateParticipantCount() {
-        var total = participants.length;
-        var shown = Math.min(visibleTileCount, total);
+        var total = totalParticipantCount || participants.length;
+        var shown = Math.min(visibleTileCount, participants.length);
 
         if (shown < total) {
           participantCountEl.textContent = shown + ' of ' + total;
@@ -406,6 +407,7 @@
 
       window.panelAPI.onParticipantsUpdate(function (data) {
         participants = data.participants || [];
+        totalParticipantCount = data.totalParticipantCount || participants.length;
 
         // Send initial pin state (local pinned by default) on first update.
         // Must run before cleanup to avoid wiping the default 'local' pin

--- a/app/features/pip/participant-panel.html
+++ b/app/features/pip/participant-panel.html
@@ -35,14 +35,14 @@
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></svg>
             <span class="chat-badge-count hidden" id="chatBadgeCount">0</span>
         </button>
-        <button class="ctrl-btn ctrl-btn-danger" id="endMeetingBtn" title="End meeting">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M10.68 13.31a16 16 0 0 0 3.41 2.6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7 2 2 0 0 1 1.72 2v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.42 19.42 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 2.59 3.4Z"/><line x1="20" x2="4" y1="4" y2="20" stroke="currentColor" stroke-width="2.5"/></svg>
-        </button>
         <button class="ctrl-btn" id="backBtn" title="Back to meeting">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
         </button>
         <button class="ctrl-btn" id="closeBtn" title="Minimize to pill">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></svg>
+        </button>
+        <button class="ctrl-btn ctrl-btn-danger" id="endMeetingBtn" title="End meeting">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M10.68 13.31a16 16 0 0 0 3.41 2.6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7 2 2 0 0 1 1.72 2v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.42 19.42 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 2.59 3.4Z"/><line x1="20" x2="4" y1="4" y2="20" stroke="currentColor" stroke-width="2.5"/></svg>
         </button>
       </div>
     </div>
@@ -366,10 +366,10 @@
         gripIcon.innerHTML = GRIP_ICON;
 
         if (currentOrientation === 'horizontal') {
-          toggleIcon.innerHTML = TOGGLE_COLUMNS;
+          toggleIcon.innerHTML = TOGGLE_ROWS;
           document.getElementById('toggleBtn').title = 'Switch to vertical layout';
         } else {
-          toggleIcon.innerHTML = TOGGLE_ROWS;
+          toggleIcon.innerHTML = TOGGLE_COLUMNS;
           document.getElementById('toggleBtn').title = 'Switch to horizontal layout';
         }
       }


### PR DESCRIPTION
Fixes #121 (non-Mac issues)

**Companion PR (jitsi-meet side):** alfaz-studio/jitsi-meet#474

## Summary
- **Participant count**: show actual conference total instead of capped tile count (max 4). Added `totalParticipantCount` to the IPC payload from jitsi-meet
- **Toggle orientation icons**: replaced Columns2/Rows2 with Lucide `arrow-up-down` / `arrow-left-right` for clearer intent
- **End call button**: moved to far right of the control bar (was in the middle)
- **Restore behavior**: restoring/maximizing the main window now closes PiP entirely instead of shrinking to pill. Pill mode is only entered via the explicit "Minimize to pill" button

## Test plan
- [ ] Open meeting with 5+ participants, minimize → PiP shows correct total count (not capped at 4)
- [ ] Toggle orientation button shows arrow-up-down (horizontal) / arrow-left-right (vertical)
- [ ] End call button is the last button on the right
- [ ] Minimize main window → PiP opens → restore main window → **PiP closes entirely** (no pill)
- [ ] Minimize → PiP opens → click "Minimize to pill" → pill appears → click pill → panel expands
- [ ] Minimize → PiP opens → click "Back to meeting" → main window restores, PiP closes