### PR TITLE
feat(notifications): cross-window OS notifications when window is unfocused

### DIFF
--- a/app/features/cross-window-notifications/main.js
+++ b/app/features/cross-window-notifications/main.js
@@ -9,6 +9,7 @@ const MAX_TITLE_LEN = 100;
 const MAX_BODY_LEN = 250;
 const PAYLOAD_MAX_AGE_MS = 10_000;
 const DEDUP_TTL_MS = 3_000;
+const MAX_RECENT_KEYS = 50;
 
 /**
  * Sets up native OS notifications for jitsi in-meeting events when the app window is unfocused.
@@ -26,6 +27,7 @@ const DEDUP_TTL_MS = 3_000;
  */
 function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
     const capture = typeof options.capture === 'function' ? options.capture : null;
+    const notificationIcon = getIconPath('png');
 
     // uid -> timestamp (ms). Drops duplicate sends within DEDUP_TTL_MS.
     const recentUids = new Map();
@@ -37,11 +39,11 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
 
     // eslint-disable-next-line require-jsdoc
     function clearAttentionSignals() {
-        if (mainWindow && !mainWindow.isDestroyed()) {
+        if (process.platform === 'win32' && mainWindow && !mainWindow.isDestroyed()) {
             try {
                 mainWindow.flashFrame(false);
             } catch {
-                // Platform may not support it.
+                // Platform doesn't support it.
             }
         }
         if (process.platform === 'darwin' && app.dock && bounceId !== null) {
@@ -82,7 +84,12 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         if (typeof payload.title !== 'string' || payload.title.trim() === '') {
             return false;
         }
-        if (typeof payload.timestamp !== 'number' || Date.now() - payload.timestamp > PAYLOAD_MAX_AGE_MS) {
+        if (typeof payload.timestamp !== 'number') {
+            return false;
+        }
+        const age = Date.now() - payload.timestamp;
+
+        if (age < 0 || age > PAYLOAD_MAX_AGE_MS) {
             return false;
         }
 
@@ -111,8 +118,6 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
 
         // Hard cap — trim oldest entries if the Map has somehow grown large
         // (e.g. a burst of distinct UIDs arrived and hasn't been cleaned yet).
-        const MAX_RECENT_KEYS = 50;
-
         while (recentUids.size > MAX_RECENT_KEYS) {
             const oldest = recentUids.keys().next().value;
 
@@ -152,7 +157,7 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         const notification = new Notification({
             title,
             body,
-            icon: getIconPath('png')
+            icon: notificationIcon
         });
 
         notification.on('click', () => {

--- a/app/features/cross-window-notifications/main.js
+++ b/app/features/cross-window-notifications/main.js
@@ -1,9 +1,11 @@
+/* eslint-disable require-jsdoc */
 'use strict';
 
 const { BrowserWindow, Notification, app } = require('electron');
 
 const { getIconPath } = require('../paths');
 
+const IPC_CHANNEL = 'cross-window-notification';
 const MAX_TITLE_LEN = 100;
 const MAX_BODY_LEN = 250;
 const PAYLOAD_MAX_AGE_MS = 10_000;
@@ -32,25 +34,21 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
     // macOS dock bounce id — stored so focus handler can cancel it.
     let bounceId = null;
 
-    // Unread count for setBadgeCount. Reset on focus.
     let unread = 0;
 
-    /**
-     * Clears taskbar flash, dock bounce, and badge count.
-     */
     function clearAttentionSignals() {
         if (mainWindow && !mainWindow.isDestroyed()) {
             try {
                 mainWindow.flashFrame(false);
             } catch {
-                // Platform may not support it — ignore.
+                // Platform may not support it.
             }
         }
         if (process.platform === 'darwin' && app.dock && bounceId !== null) {
             try {
                 app.dock.cancelBounce(bounceId);
             } catch {
-                // Bounce already finished — ignore.
+                // Bounce already finished.
             }
             bounceId = null;
         }
@@ -59,14 +57,11 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
             try {
                 app.setBadgeCount(0);
             } catch {
-                // Unsupported platform — ignore.
+                // Unsupported platform.
             }
         }
     }
 
-    /**
-     * Restores, shows and focuses the main window.
-     */
     function focusMainWindow() {
         if (!mainWindow || mainWindow.isDestroyed()) {
             return;
@@ -78,12 +73,6 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         mainWindow.focus();
     }
 
-    /**
-     * Validates the IPC payload shape and freshness.
-     *
-     * @param {object} payload
-     * @returns {boolean}
-     */
     function isPayloadValid(payload) {
         if (!payload || typeof payload !== 'object') {
             return false;
@@ -98,12 +87,6 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         return true;
     }
 
-    /**
-     * Returns true if the given uid was seen within DEDUP_TTL_MS, otherwise records it.
-     *
-     * @param {string|undefined} uid
-     * @returns {boolean}
-     */
     function isDuplicate(uid) {
         if (!uid) {
             return false;
@@ -126,13 +109,6 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         return false;
     }
 
-    /**
-     * IPC listener for 'cross-window-notification'. Pops a native OS toast
-     * + flash/bounce/badge when no app window is focused.
-     *
-     * @param {Electron.IpcMainEvent} _event
-     * @param {object} payload
-     */
     function onNotification(_event, payload) {
         if (!mainWindow || mainWindow.isDestroyed()) {
             return;
@@ -143,11 +119,11 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
             return;
         }
 
-        if (!isPayloadValid(payload)) {
+        if (!isPayloadValid(payload) || isDuplicate(payload.uid)) {
             return;
         }
 
-        if (isDuplicate(payload.uid)) {
+        if (!Notification.isSupported()) {
             return;
         }
 
@@ -155,10 +131,6 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         const body = typeof payload.body === 'string'
             ? payload.body.slice(0, MAX_BODY_LEN)
             : '';
-
-        if (!Notification.isSupported()) {
-            return;
-        }
 
         const notification = new Notification({
             title,
@@ -174,16 +146,12 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
 
         notification.show();
 
-        // Taskbar flash (Windows; no-op elsewhere).
-        if (process.platform === 'win32' && mainWindow && !mainWindow.isDestroyed()) {
+        if (process.platform === 'win32') {
             try {
                 mainWindow.flashFrame(true);
-            } catch {
-                // Ignore.
-            }
+            } catch { /* empty */ }
         }
 
-        // Dock bounce (macOS).
         if (process.platform === 'darwin' && app.dock) {
             try {
                 // Cancel any previous bounce so we don't stack.
@@ -191,18 +159,14 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
                     app.dock.cancelBounce(bounceId);
                 }
                 bounceId = app.dock.bounce('informational');
-            } catch {
-                // Ignore.
-            }
+            } catch { /* empty */ }
         }
 
         // Badge count — works on macOS dock, no-op on Windows (non-Unity Linux too).
         unread += 1;
         try {
             app.setBadgeCount(unread);
-        } catch {
-            // Ignore.
-        }
+        } catch { /* empty */ }
 
         if (capture) {
             capture('cross_window_notification_shown', {
@@ -212,22 +176,15 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         }
     }
 
-    /**
-     * Window 'focus' handler — clears flash/bounce/badge when user returns.
-     */
     function onFocus() {
         clearAttentionSignals();
     }
 
-    ipcMain.on('cross-window-notification', onNotification);
+    ipcMain.on(IPC_CHANNEL, onNotification);
+    mainWindow.on('focus', onFocus);
 
-    if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.on('focus', onFocus);
-    }
-
-    // eslint-disable-next-line require-jsdoc
     return function cleanup() {
-        ipcMain.removeListener('cross-window-notification', onNotification);
+        ipcMain.removeListener(IPC_CHANNEL, onNotification);
         if (mainWindow && !mainWindow.isDestroyed()) {
             mainWindow.removeListener('focus', onFocus);
         }

--- a/app/features/cross-window-notifications/main.js
+++ b/app/features/cross-window-notifications/main.js
@@ -1,4 +1,3 @@
-/* eslint-disable require-jsdoc */
 'use strict';
 
 const { BrowserWindow, Notification, app } = require('electron');
@@ -36,6 +35,7 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
 
     let unread = 0;
 
+    // eslint-disable-next-line require-jsdoc
     function clearAttentionSignals() {
         if (mainWindow && !mainWindow.isDestroyed()) {
             try {
@@ -62,6 +62,7 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         }
     }
 
+    // eslint-disable-next-line require-jsdoc
     function focusMainWindow() {
         if (!mainWindow || mainWindow.isDestroyed()) {
             return;
@@ -73,6 +74,7 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         mainWindow.focus();
     }
 
+    // eslint-disable-next-line require-jsdoc
     function isPayloadValid(payload) {
         if (!payload || typeof payload !== 'object') {
             return false;
@@ -87,8 +89,9 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         return true;
     }
 
+    // eslint-disable-next-line require-jsdoc
     function isDuplicate(uid) {
-        if (!uid) {
+        if (uid === undefined || uid === null) {
             return false;
         }
         const now = Date.now();
@@ -106,9 +109,23 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
             }
         }
 
+        // Hard cap — trim oldest entries if the Map has somehow grown large
+        // (e.g. a burst of distinct UIDs arrived and hasn't been cleaned yet).
+        const MAX_RECENT_KEYS = 50;
+
+        while (recentUids.size > MAX_RECENT_KEYS) {
+            const oldest = recentUids.keys().next().value;
+
+            if (oldest === undefined) {
+                break;
+            }
+            recentUids.delete(oldest);
+        }
+
         return false;
     }
 
+    // eslint-disable-next-line require-jsdoc
     function onNotification(_event, payload) {
         if (!mainWindow || mainWindow.isDestroyed()) {
             return;
@@ -135,8 +152,7 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         const notification = new Notification({
             title,
             body,
-            icon: getIconPath('png'),
-            silent: false
+            icon: getIconPath('png')
         });
 
         notification.on('click', () => {
@@ -176,6 +192,7 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         }
     }
 
+    // eslint-disable-next-line require-jsdoc
     function onFocus() {
         clearAttentionSignals();
     }
@@ -183,6 +200,7 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
     ipcMain.on(IPC_CHANNEL, onNotification);
     mainWindow.on('focus', onFocus);
 
+    // eslint-disable-next-line require-jsdoc
     return function cleanup() {
         ipcMain.removeListener(IPC_CHANNEL, onNotification);
         if (mainWindow && !mainWindow.isDestroyed()) {

--- a/app/features/cross-window-notifications/main.js
+++ b/app/features/cross-window-notifications/main.js
@@ -1,0 +1,239 @@
+'use strict';
+
+const { BrowserWindow, Notification, app } = require('electron');
+
+const { getIconPath } = require('../paths');
+
+const MAX_TITLE_LEN = 100;
+const MAX_BODY_LEN = 250;
+const PAYLOAD_MAX_AGE_MS = 10_000;
+const DEDUP_TTL_MS = 3_000;
+
+/**
+ * Sets up native OS notifications for jitsi in-meeting events when the app window is unfocused.
+ *
+ * The renderer (jitsi-meet) forwards allowlisted notifications over the
+ * 'cross-window-notification' IPC channel. This module checks focus state and,
+ * when no app window has focus, pops a native Notification + flashes the taskbar
+ * (Windows) / bounces the dock (macOS) / sets an unread badge. Clicking the toast
+ * restores and focuses the main window. Focus clears all three attention signals.
+ *
+ * @param {Electron.IpcMain} ipcMain
+ * @param {Electron.BrowserWindow} mainWindow
+ * @param {{ capture?: (event: string, props?: object) => void }} [options]
+ * @returns {() => void} Cleanup function — call from mainWindow 'closed'.
+ */
+function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
+    const capture = typeof options.capture === 'function' ? options.capture : null;
+
+    // uid -> timestamp (ms). Drops duplicate sends within DEDUP_TTL_MS.
+    const recentUids = new Map();
+
+    // macOS dock bounce id — stored so focus handler can cancel it.
+    let bounceId = null;
+
+    // Unread count for setBadgeCount. Reset on focus.
+    let unread = 0;
+
+    /**
+     * Clears taskbar flash, dock bounce, and badge count.
+     */
+    function clearAttentionSignals() {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+            try {
+                mainWindow.flashFrame(false);
+            } catch {
+                // Platform may not support it — ignore.
+            }
+        }
+        if (process.platform === 'darwin' && app.dock && bounceId !== null) {
+            try {
+                app.dock.cancelBounce(bounceId);
+            } catch {
+                // Bounce already finished — ignore.
+            }
+            bounceId = null;
+        }
+        if (unread > 0) {
+            unread = 0;
+            try {
+                app.setBadgeCount(0);
+            } catch {
+                // Unsupported platform — ignore.
+            }
+        }
+    }
+
+    /**
+     * Restores, shows and focuses the main window.
+     */
+    function focusMainWindow() {
+        if (!mainWindow || mainWindow.isDestroyed()) {
+            return;
+        }
+        if (mainWindow.isMinimized()) {
+            mainWindow.restore();
+        }
+        mainWindow.show();
+        mainWindow.focus();
+    }
+
+    /**
+     * Validates the IPC payload shape and freshness.
+     *
+     * @param {object} payload
+     * @returns {boolean}
+     */
+    function isPayloadValid(payload) {
+        if (!payload || typeof payload !== 'object') {
+            return false;
+        }
+        if (typeof payload.title !== 'string' || payload.title.trim() === '') {
+            return false;
+        }
+        if (typeof payload.timestamp !== 'number' || Date.now() - payload.timestamp > PAYLOAD_MAX_AGE_MS) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if the given uid was seen within DEDUP_TTL_MS, otherwise records it.
+     *
+     * @param {string|undefined} uid
+     * @returns {boolean}
+     */
+    function isDuplicate(uid) {
+        if (!uid) {
+            return false;
+        }
+        const now = Date.now();
+        const last = recentUids.get(uid);
+
+        if (last && now - last < DEDUP_TTL_MS) {
+            return true;
+        }
+        recentUids.set(uid, now);
+
+        // Opportunistic cleanup — drop entries older than TTL.
+        for (const [ k, t ] of recentUids) {
+            if (now - t >= DEDUP_TTL_MS) {
+                recentUids.delete(k);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * IPC listener for 'cross-window-notification'. Pops a native OS toast
+     * + flash/bounce/badge when no app window is focused.
+     *
+     * @param {Electron.IpcMainEvent} _event
+     * @param {object} payload
+     */
+    function onNotification(_event, payload) {
+        if (!mainWindow || mainWindow.isDestroyed()) {
+            return;
+        }
+
+        // Any of our windows focused → drop. In-app React toast already shows.
+        if (BrowserWindow.getFocusedWindow() !== null) {
+            return;
+        }
+
+        if (!isPayloadValid(payload)) {
+            return;
+        }
+
+        if (isDuplicate(payload.uid)) {
+            return;
+        }
+
+        const title = String(payload.title).slice(0, MAX_TITLE_LEN);
+        const body = typeof payload.body === 'string'
+            ? payload.body.slice(0, MAX_BODY_LEN)
+            : '';
+
+        if (!Notification.isSupported()) {
+            return;
+        }
+
+        const notification = new Notification({
+            title,
+            body,
+            icon: getIconPath('png'),
+            silent: false
+        });
+
+        notification.on('click', () => {
+            focusMainWindow();
+            clearAttentionSignals();
+        });
+
+        notification.show();
+
+        // Taskbar flash (Windows; no-op elsewhere).
+        if (process.platform === 'win32' && mainWindow && !mainWindow.isDestroyed()) {
+            try {
+                mainWindow.flashFrame(true);
+            } catch {
+                // Ignore.
+            }
+        }
+
+        // Dock bounce (macOS).
+        if (process.platform === 'darwin' && app.dock) {
+            try {
+                // Cancel any previous bounce so we don't stack.
+                if (bounceId !== null) {
+                    app.dock.cancelBounce(bounceId);
+                }
+                bounceId = app.dock.bounce('informational');
+            } catch {
+                // Ignore.
+            }
+        }
+
+        // Badge count — works on macOS dock, no-op on Windows (non-Unity Linux too).
+        unread += 1;
+        try {
+            app.setBadgeCount(unread);
+        } catch {
+            // Ignore.
+        }
+
+        if (capture) {
+            capture('cross_window_notification_shown', {
+                uid: payload.uid || null,
+                appearance: payload.appearance || null
+            });
+        }
+    }
+
+    /**
+     * Window 'focus' handler — clears flash/bounce/badge when user returns.
+     */
+    function onFocus() {
+        clearAttentionSignals();
+    }
+
+    ipcMain.on('cross-window-notification', onNotification);
+
+    if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.on('focus', onFocus);
+    }
+
+    // eslint-disable-next-line require-jsdoc
+    return function cleanup() {
+        ipcMain.removeListener('cross-window-notification', onNotification);
+        if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.removeListener('focus', onFocus);
+        }
+        recentUids.clear();
+        clearAttentionSignals();
+    };
+}
+
+module.exports = { setupCrossWindowNotifications };

--- a/app/features/cross-window-notifications/main.js
+++ b/app/features/cross-window-notifications/main.js
@@ -1,3 +1,4 @@
+/* eslint-disable require-jsdoc */
 'use strict';
 
 const { BrowserWindow, Notification, app } = require('electron');
@@ -37,7 +38,6 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
 
     let unread = 0;
 
-    // eslint-disable-next-line require-jsdoc
     function clearAttentionSignals() {
         if (process.platform === 'win32' && mainWindow && !mainWindow.isDestroyed()) {
             try {
@@ -64,7 +64,6 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         }
     }
 
-    // eslint-disable-next-line require-jsdoc
     function focusMainWindow() {
         if (!mainWindow || mainWindow.isDestroyed()) {
             return;
@@ -76,7 +75,6 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         mainWindow.focus();
     }
 
-    // eslint-disable-next-line require-jsdoc
     function isPayloadValid(payload) {
         if (!payload || typeof payload !== 'object') {
             return false;
@@ -96,7 +94,6 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         return true;
     }
 
-    // eslint-disable-next-line require-jsdoc
     function isDuplicate(uid) {
         if (uid === undefined || uid === null) {
             return false;
@@ -130,9 +127,14 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
         return false;
     }
 
-    // eslint-disable-next-line require-jsdoc
-    function onNotification(_event, payload) {
+    function onNotification(event, payload) {
         if (!mainWindow || mainWindow.isDestroyed()) {
+            return;
+        }
+
+        // Only accept messages from the main window's renderer, matching the
+        // pattern used by other IPC handlers in main.js (onLeaveModal, etc).
+        if (event.sender !== mainWindow.webContents) {
             return;
         }
 
@@ -191,13 +193,12 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
 
         if (capture) {
             capture('cross_window_notification_shown', {
-                uid: payload.uid || null,
-                appearance: payload.appearance || null
+                uid: payload.uid ?? null,
+                appearance: payload.appearance ?? null
             });
         }
     }
 
-    // eslint-disable-next-line require-jsdoc
     function onFocus() {
         clearAttentionSignals();
     }
@@ -205,7 +206,6 @@ function setupCrossWindowNotifications(ipcMain, mainWindow, options = {}) {
     ipcMain.on(IPC_CHANNEL, onNotification);
     mainWindow.on('focus', onFocus);
 
-    // eslint-disable-next-line require-jsdoc
     return function cleanup() {
         ipcMain.removeListener(IPC_CHANNEL, onNotification);
         if (mainWindow && !mainWindow.isDestroyed()) {

--- a/app/preload/preload.js
+++ b/app/preload/preload.js
@@ -51,7 +51,8 @@ const whitelistedIpcChannels = [
     'retry-load',
     'update-toast-action',
     'leave-modal-action',
-    'deeplink-modal-action'
+    'deeplink-modal-action',
+    'cross-window-notification'
 ];
 
 // Raise the listener cap — the preload subscribes to many channels across the app

--- a/main.js
+++ b/main.js
@@ -50,6 +50,7 @@ if (process.platform === 'win32') {
 }
 
 const config = require('./app/features/config');
+const { setupCrossWindowNotifications } = require('./app/features/cross-window-notifications/main');
 const {
     registerProtocol,
     navigateDeepLink
@@ -689,6 +690,8 @@ function createJitsiMeetWindow() {
         capture
     });
 
+    const cleanupCrossWindowNotifications = setupCrossWindowNotifications(ipcMain, mainWindow, { capture });
+
     windowState.manage(mainWindow);
 
     // Show a branded splash screen first, then navigate to the remote URL.
@@ -912,6 +915,7 @@ function createJitsiMeetWindow() {
 
         // Remove PiP IPC listeners to prevent accumulation on window recreation (macOS).
         cleanupPip();
+        cleanupCrossWindowNotifications();
 
         // Destroy the participant PiP panel (may still be alive in pill mode).
         closeParticipantWindow(false);


### PR DESCRIPTION
Closes #126
Companion PR: https://github.com/alfaz-studio/jitsi-meet/pull/503

## Summary
Adds native OS notifications for important in-meeting events when the Electron window is unfocused — lobby knocks, moderation requests, raised hands, remote mute/kick, visitor requests. Uses native `Notification` + `flashFrame` (Win) / `dock.bounce` (mac) / `setBadgeCount` (mac dock / Unity). Click-to-focus restores the window.

The escalation list lives on the renderer side (companion PR) so adding/removing notifications is a one-line change there.

## Notes
- v2 (Admit/Reject buttons on the toast) deferred — works in production but Windows strips action buttons in `npm run electron` dev mode, see issue for context. Plan saved locally for future revisit.
- Dev caveat: macOS unsigned dev builds may silently drop native notifications. Test in a packaged build for full verification.

## Test plan
- [ ] Trigger a real lobby knock from a second tab while Electron is unfocused → native toast appears + taskbar flashes / dock bounces
- [ ] Click the toast → window focuses, flash/badge clear
- [ ] Trigger a notification while Electron is focused → no native toast (in-app React toast shows instead)
- [ ] Trigger a non-allowlisted notification (e.g. reaction, calendar reminder) → no native toast
- [ ] Close window with the cleanup function — verify no listener leaks via `ipcMain.eventNames()`