### PR TITLE
fix(deep-link): clean leave flow, prevent PiP hijack and app close

### DIFF
--- a/app/features/deep-link.js
+++ b/app/features/deep-link.js
@@ -2,10 +2,181 @@ const { app, ipcMain } = require('electron');
 const path = require('path');
 
 const config = require('./config');
+const { t } = require('./i18n');
+const { showDeeplinkModal } = require('./in-app-dialogs');
 const { getMainWindow } = require('./overlay/helpers');
 const { closeOverlay } = require('./overlay/overlay-window');
-const { showDeeplinkModal } = require('./in-app-dialogs');
-const { t } = require('./i18n');
+const { closeParticipantWindow } = require('./pip/participant-window');
+
+/**
+ * Max wait for jitsi's leaveConference() flow to reach /static/close before
+ * we force the deep-link navigation anyway. If the renderer is unresponsive
+ * or somehow skips the hangup redirect, this guarantees the user still gets
+ * into the new meeting.
+ */
+const DEEPLINK_LEAVE_TIMEOUT_MS = 5000;
+
+/**
+ * True while a deep-link triggered loadURL is in flight. The main window's
+ * will-prevent-unload handler checks this to skip the "Leave Meeting?" quit
+ * modal — the user already confirmed the deep-link modal, and falling into
+ * the quit flow would destroy the window instead of navigating.
+ */
+let deeplinkNavigating = false;
+
+/**
+ * When non-null, a deep-link navigation is waiting for the in-progress
+ * leaveConference() flow to reach /static/close. Shape:
+ * `{ targetUrl: string, timer: Timeout }`.
+ *
+ * Consumed by completeDeeplinkNavigation(), which main.js invokes from its
+ * will-navigate handler when /static/close is reached (or by the fallback
+ * timer if that redirect never happens).
+ */
+let pendingDeeplink = null;
+
+/**
+ * Tracks the currently-displayed deep-link modal so that a newer deep-link
+ * can tear down the older one completely: remove the IPC listener by
+ * reference, cancel the 60s timeout, and resolve the stalled promise with
+ * 'cancel' (avoids leaking a live async frame for up to a minute).
+ *
+ * Shape: `{ handler: Function, cancelTimer: Timeout, resolve: Function }`.
+ */
+let pendingDeeplinkModal = null;
+
+/**
+ * Reads the deep-link-navigating flag and clears it atomically.
+ *
+ * The main window's will-prevent-unload handler calls this to decide
+ * whether to bypass the "Leave Meeting?" quit modal. Clearing on read
+ * makes the lifetime event-driven — the flag is cleared exactly when it
+ * served its purpose, regardless of timing.
+ *
+ * Named `take*` (not `is*`) to signal that it mutates state on call —
+ * it's not a predicate.
+ *
+ * @returns {boolean} True if a deep-link load was in flight (and the flag
+ *  has now been cleared).
+ */
+function takeDeeplinkNavigating() {
+    const was = deeplinkNavigating;
+
+    deeplinkNavigating = false;
+
+    return was;
+}
+
+/**
+ * @returns {boolean} True while we're waiting for leaveConference() to
+ *  reach /static/close before the deep-link navigation can complete.
+ */
+function isDeeplinkPending() {
+    return pendingDeeplink !== null;
+}
+
+/**
+ * Loads the target URL in the given window, setting the beforeunload-bypass
+ * flag briefly in case a residual beforeunload handler is still attached.
+ *
+ * @param {BrowserWindow} win - The window to navigate.
+ * @param {string} targetUrl - The destination URL.
+ */
+function performDeeplinkLoad(win, targetUrl) {
+    deeplinkNavigating = true;
+
+    // Clear the flag as soon as navigation actually starts.
+    // `did-start-navigation` fires AFTER beforeunload is resolved — so if
+    // will-prevent-unload was going to consume the flag, it already has.
+    // Clearing here (instead of after a fixed timeout) prevents the flag
+    // from lingering into an unrelated close attempt the user might make
+    // a second or two later, which would silently bypass the leave-modal.
+    let safetyTimer;
+    const clearFlag = () => {
+        deeplinkNavigating = false;
+        clearTimeout(safetyTimer);
+    };
+
+    win.webContents.once('did-start-navigation', clearFlag);
+
+    // Safety: if did-start-navigation never fires (window destroyed during
+    // load, loadURL rejected, etc.) still clear the flag so it doesn't
+    // stick indefinitely. Guard webContents access — it throws when the
+    // window was destroyed during the 2s window.
+    safetyTimer = setTimeout(() => {
+        deeplinkNavigating = false;
+        if (!win.isDestroyed()) {
+            win.webContents.removeListener('did-start-navigation', clearFlag);
+        }
+    }, 2000);
+
+    // Restore + show + focus before loadURL so the navigation happens
+    // against a visible window. isMinimized() is false when the window is
+    // hidden (win.hide() / macOS cmd+H), so show() is required — focus()
+    // alone won't un-hide a hidden window.
+    if (win.isMinimized()) {
+        win.restore();
+    }
+    win.show();
+    win.focus();
+    win.loadURL(targetUrl);
+}
+
+/**
+ * Tears down any in-flight deep-link state. Call from main.js on window
+ * close so the 60s modal-cancel timer and 5s leave-fallback timer don't
+ * keep ticking after the window is gone (low-impact — handlers no-op on
+ * a destroyed window — but tidier).
+ */
+function cleanupDeeplinkState() {
+    if (pendingDeeplinkModal) {
+        ipcMain.removeListener('deeplink-modal-action', pendingDeeplinkModal.handler);
+        clearTimeout(pendingDeeplinkModal.cancelTimer);
+        pendingDeeplinkModal.resolve('cancel');
+        pendingDeeplinkModal = null;
+    }
+    if (pendingDeeplink) {
+        clearTimeout(pendingDeeplink.timer);
+        pendingDeeplink = null;
+    }
+    deeplinkNavigating = false;
+}
+
+/**
+ * Completes a pending deep-link navigation: clears the fallback timer,
+ * closes the participant PiP panel, and loads the stored target URL.
+ *
+ * Called from main.js's will-navigate handler when /static/close fires
+ * after leaveConference(), and also by the fallback timer if that
+ * redirect never arrives.
+ *
+ * @returns {boolean} True if a pending navigation was consumed.
+ */
+function completeDeeplinkNavigation() {
+    if (!pendingDeeplink) {
+        return false;
+    }
+
+    const { targetUrl, timer } = pendingDeeplink;
+
+    clearTimeout(timer);
+    pendingDeeplink = null;
+
+    const win = getMainWindow();
+
+    if (!win || win.isDestroyed()) {
+        return false;
+    }
+
+    // Ensure the PiP panel is gone. The renderer's cleanup IPC usually
+    // handles this via SCREENSHARE_STOP, but pill mode is skipped there,
+    // and the IPC can race with the page unload. Idempotent.
+    closeParticipantWindow(false);
+
+    performDeeplinkLoad(win, targetUrl);
+
+    return true;
+}
 
 /**
  * Registers the custom protocol scheme for the application.
@@ -73,53 +244,106 @@ async function navigateDeepLink(deepLink) {
 
         const win = getMainWindow();
 
-        if (win) {
-            // Check if user is currently in a meeting
-            try {
-                const currentUrl = new URL(win.webContents.getURL());
+        if (!win) {
+            return false;
+        }
 
-                if (currentUrl.pathname.startsWith('/meet')) {
-                    // Remove any stale listener from a previous deep link
-                    ipcMain.removeAllListeners('deeplink-modal-action');
+        // Check if user is currently in a meeting
+        let inMeeting = false;
 
-                    showDeeplinkModal(win.webContents, {
-                        title: t('deeplinkModal.title'),
-                        message: t('deeplinkModal.message'),
-                        confirm: t('deeplinkModal.confirm'),
-                        cancel: t('deeplinkModal.cancel')
-                    });
+        try {
+            const currentUrl = new URL(win.webContents.getURL());
 
-                    const TIMEOUT_MS = 60000;
-                    const action = await new Promise(resolve => {
-                        const timer = setTimeout(() => {
-                            ipcMain.removeAllListeners('deeplink-modal-action');
-                            resolve('cancel');
-                        }, TIMEOUT_MS);
+            inMeeting = currentUrl.pathname.startsWith('/meet');
+        } catch (e) { /* ignore URL parse errors */ }
 
-                        ipcMain.once('deeplink-modal-action', (_event, data) => {
-                            clearTimeout(timer);
-                            resolve(data?.action);
-                        });
-                    });
-
-                    if (action !== 'confirm') {
-                        return false;
-                    }
-
-                    closeOverlay(false, 'deep-link-navigation');
-                }
-            } catch (e) { /* ignore URL parse errors */ }
-
-            win.loadURL(targetUrl);
-            if (win.isMinimized()) {
-                win.restore();
+        if (inMeeting) {
+            // Tear down any modal left over from a superseded deep-link:
+            // remove the IPC listener by reference (not removeAllListeners
+            // — a third party could legitimately listen on this channel in
+            // the future), cancel the 60s timeout, and resolve the old
+            // promise so it doesn't leak a live async frame.
+            if (pendingDeeplinkModal) {
+                ipcMain.removeListener('deeplink-modal-action', pendingDeeplinkModal.handler);
+                clearTimeout(pendingDeeplinkModal.cancelTimer);
+                pendingDeeplinkModal.resolve('cancel');
+                pendingDeeplinkModal = null;
             }
-            win.focus();
+
+            showDeeplinkModal(win.webContents, {
+                title: t('deeplinkModal.title'),
+                message: t('deeplinkModal.message'),
+                confirm: t('deeplinkModal.confirm'),
+                cancel: t('deeplinkModal.cancel')
+            });
+
+            const TIMEOUT_MS = 60000;
+            const action = await new Promise(resolve => {
+                const cancelTimer = setTimeout(() => {
+                    if (pendingDeeplinkModal) {
+                        ipcMain.removeListener('deeplink-modal-action', pendingDeeplinkModal.handler);
+                        pendingDeeplinkModal = null;
+                    }
+                    resolve('cancel');
+                }, TIMEOUT_MS);
+
+                const handler = (_event, data) => {
+                    pendingDeeplinkModal = null;
+                    clearTimeout(cancelTimer);
+                    resolve(data?.action);
+                };
+
+                pendingDeeplinkModal = { handler, cancelTimer, resolve };
+                ipcMain.once('deeplink-modal-action', handler);
+            });
+
+            if (action !== 'confirm') {
+                return false;
+            }
+
+            closeOverlay(false, 'deep-link-navigation');
+
+            // If a previous deep-link leave is still in flight, replace its
+            // target — the user's most recent confirmation wins — but don't
+            // re-send pip-end-meeting below; the renderer is already tearing
+            // the conference down and a second trigger could interfere.
+            const leaveAlreadyInFlight = pendingDeeplink !== null;
+
+            if (pendingDeeplink) {
+                clearTimeout(pendingDeeplink.timer);
+            }
+
+            pendingDeeplink = {
+                targetUrl,
+                // Known edge case: if the renderer sends /static/close at
+                // nearly the same millisecond this timer fires, the timer
+                // clears pendingDeeplink first and main.js's will-navigate
+                // handler falls through to the normal dashboard redirect
+                // path (`setImmediate(loadURL(closePageUrl))`). The timer's
+                // loadURL has already been issued by then, so the target
+                // meeting wins in practice — worst case is a brief flash
+                // of the dashboard-close URL before the new meeting loads.
+                timer: setTimeout(() => {
+                    console.warn('⚠️ Deep-link leave timeout — forcing navigation.');
+                    completeDeeplinkNavigation();
+                }, DEEPLINK_LEAVE_TIMEOUT_MS)
+            };
+
+            // Trigger the same leaveConference() flow the leave-modal uses.
+            // Renderer handles the clean XMPP leave, then navigates to
+            // /static/close — main.js's will-navigate handler sees the
+            // pending deeplink and finishes the navigation.
+            if (!leaveAlreadyInFlight) {
+                win.webContents.send('pip-end-meeting');
+            }
 
             return true;
         }
 
-        return false;
+        // Not in a meeting — navigate directly.
+        performDeeplinkLoad(win, targetUrl);
+
+        return true;
     } catch (error) {
         console.error('Error parsing deep link:', error);
 
@@ -129,5 +353,9 @@ async function navigateDeepLink(deepLink) {
 
 module.exports = {
     registerProtocol,
-    navigateDeepLink
+    navigateDeepLink,
+    takeDeeplinkNavigating,
+    isDeeplinkPending,
+    completeDeeplinkNavigation,
+    cleanupDeeplinkState
 };

--- a/app/features/ipc.js
+++ b/app/features/ipc.js
@@ -9,10 +9,10 @@ const {
     sendParticipantsUpdate,
     closeParticipantWindow,
     shrinkToPill,
-    getParticipantWindow,
     getCurrentState,
 } = require('./pip/participant-window');
 const { IPC } = require('./pip/constants');
+const { getParticipantWindow } = require('./pip/helpers');
 
 /**
  * Previously registered listeners as [channel, fn] pairs.

--- a/app/features/overlay/helpers.js
+++ b/app/features/overlay/helpers.js
@@ -1,7 +1,9 @@
 const { BrowserWindow, app } = require('electron');
+const isDev = require('electron-is-dev');
 const fs = require('fs');
 const path = require('path');
-const isDev = require('electron-is-dev');
+
+const { getParticipantWindow } = require('../pip/helpers');
 
 const { OVERLAY_PRELOAD_FILENAME } = require('./constants');
 const { overlayWindows } = require('./window-factory');
@@ -9,12 +11,19 @@ const { overlayWindows } = require('./window-factory');
 // ── Window lookup ───────────────────────────────────────────────────────────
 
 /**
- * Finds the main Sonacove application window.
+ * Finds the main Sonacove application window, excluding auxiliary windows
+ * (annotation overlays and the participant PiP panel). The PiP panel must be
+ * excluded explicitly — it's always-on-top with skipTaskbar, so a naive
+ * "first visible window" search returns it whenever the main window is
+ * minimized or hidden (e.g. deep-link navigation while PiP is open).
  *
- * @returns {BrowserWindow|undefined} The main window instance.
+ * @returns {BrowserWindow|null} The main window instance, or null if none.
  */
 function getMainWindow() {
-    const windows = BrowserWindow.getAllWindows().filter(w => !w.isDestroyed() && !overlayWindows.has(w));
+    const participantWin = getParticipantWindow();
+    const windows = BrowserWindow.getAllWindows().filter(
+        w => !w.isDestroyed() && !overlayWindows.has(w) && w !== participantWin
+    );
 
     // 1. Try by visibility (more reliable than title which may not be set during startup)
     const visible = windows.find(w => w.isVisible());
@@ -23,8 +32,8 @@ function getMainWindow() {
         return visible;
     }
 
-    // 2. Fallback
-    return windows[0];
+    // 2. Fallback — normalized to null (matches pip/helpers:getMainWindowExcludingPip)
+    return windows[0] || null;
 }
 
 /**

--- a/app/features/pip/helpers.js
+++ b/app/features/pip/helpers.js
@@ -10,8 +10,9 @@ const path = require('path');
 let _participantWindow = null;
 
 /**
- * Sets the participant window reference so getMainWindow() can exclude it.
- * Called by participant-window.js whenever the window is created or destroyed.
+ * Sets the participant window reference so getMainWindowExcludingPip() and
+ * overlay/helpers:getMainWindow can exclude it. Called by
+ * participant-window.js whenever the window is created or destroyed.
  *
  * @param {BrowserWindow|null} win
  */
@@ -20,15 +21,37 @@ function setParticipantWindow(win) {
 }
 
 /**
- * Returns the actual main application window, excluding the PiP panel.
- *
- * The generic "first visible window" approach fails when the main window is
- * minimized because the always-on-top PiP panel becomes the first visible
- * window instead.
+ * Returns the participant PiP window reference (or null). Exported so that
+ * other features' main-window lookups (e.g. overlay/helpers, deep-link) can
+ * exclude it — the always-on-top PiP panel would otherwise be picked as the
+ * "first visible" window when the main window is minimized/hidden.
  *
  * @returns {BrowserWindow|null}
  */
-function getMainWindow() {
+function getParticipantWindow() {
+    return _participantWindow;
+}
+
+/**
+ * Returns the first non-destroyed window that isn't the participant PiP
+ * panel. Pip-internal helper only.
+ *
+ * ⚠ DO NOT use outside the `pip/` feature. This helper exists solely to
+ * avoid a circular require back into `overlay/helpers`, and it has two
+ * limitations compared to `overlay/helpers:getMainWindow`:
+ *
+ *   1. It does NOT exclude annotation overlay windows — an overlay could
+ *      be returned if present.
+ *   2. It does NOT prefer visible windows — it returns the first
+ *      non-destroyed match.
+ *
+ * These are acceptable for pip-internal use (display geometry / bounds
+ * lookups) but wrong for routing user intent. External callers should use
+ * `overlay/helpers:getMainWindow` instead.
+ *
+ * @returns {BrowserWindow|null}
+ */
+function getMainWindowExcludingPip() {
     const windows = BrowserWindow.getAllWindows().filter(
         w => !w.isDestroyed() && w !== _participantWindow
     );
@@ -56,6 +79,7 @@ function resolveFile(filename, featureDir) {
 
 module.exports = {
     setParticipantWindow,
-    getMainWindow,
+    getParticipantWindow,
+    getMainWindowExcludingPip,
     resolveFile,
 };

--- a/app/features/pip/participant-window.js
+++ b/app/features/pip/participant-window.js
@@ -9,7 +9,7 @@
 const { app, BrowserWindow, ipcMain, screen } = require('electron');
 
 const { TILE_W, TILE_PAD, H_TILE_H, HEADER_H, BORDER, IPC } = require('./constants');
-const { setParticipantWindow, getMainWindow, resolveFile } = require('./helpers');
+const { setParticipantWindow, getMainWindowExcludingPip: getMainWindow, resolveFile } = require('./helpers');
 const { computeWindowSize, getWindowPosition } = require('./sizing');
 const { setupDragHandlers, isDragging } = require('./drag');
 const { setupPillHandlers, isPillMode, shrinkToPill, reset: resetPill } = require('./pill');
@@ -315,16 +315,11 @@ function closeParticipantWindow(notifyUserClosed = false) {
     }
 }
 
-function getParticipantWindow() {
-    return participantWindow;
-}
-
 module.exports = {
     openParticipantWindow,
     sendParticipantFrame,
     sendParticipantsUpdate,
     closeParticipantWindow,
     shrinkToPill,
-    getParticipantWindow,
     getCurrentState: getState,
 };

--- a/app/features/pip/pill.js
+++ b/app/features/pip/pill.js
@@ -7,7 +7,7 @@
 
 const { ipcMain, screen } = require('electron');
 const { PILL_SIZE, MARGIN, IPC } = require('./constants');
-const { getMainWindow } = require('./helpers');
+const { getMainWindowExcludingPip: getMainWindow } = require('./helpers');
 const { computeWindowSize, getWindowPosition } = require('./sizing');
 const { setVisibleTileCount } = require('./resize');
 

--- a/main.js
+++ b/main.js
@@ -52,7 +52,11 @@ if (process.platform === 'win32') {
 const config = require('./app/features/config');
 const {
     registerProtocol,
-    navigateDeepLink
+    navigateDeepLink,
+    takeDeeplinkNavigating,
+    isDeeplinkPending,
+    completeDeeplinkNavigation,
+    cleanupDeeplinkState
 } = require('./app/features/deep-link');
 const { setupSonacoveIPC } = require('./app/features/ipc');
 const { closeOverlay } = require('./app/features/overlay/overlay-window');
@@ -477,7 +481,20 @@ function createJitsiMeetWindow() {
     // Not calling event.preventDefault() keeps the page open (prevents unload).
     // If the user confirms "Leave", the IPC handler triggers a clean XMPP leave
     // via pip-end-meeting, then the will-navigate handler destroys the window.
-    mainWindow.webContents.on('will-prevent-unload', () => {
+    //
+    // Exception: deep-link navigation. deep-link.js's loadURL also fires
+    // will-prevent-unload; in that case the user already confirmed the
+    // deep-link modal, so event.preventDefault() overrides the beforeunload
+    // block and lets the navigation proceed. takeDeeplinkNavigating()
+    // reads and clears the flag atomically so it can't leak into a later
+    // unrelated close attempt.
+    mainWindow.webContents.on('will-prevent-unload', event => {
+        if (takeDeeplinkNavigating()) {
+            event.preventDefault();
+
+            return;
+        }
+
         showLeaveModal(mainWindow.webContents, {
             title: t('leaveModal.title'),
             message: t('leaveModal.message'),
@@ -632,8 +649,29 @@ function createJitsiMeetWindow() {
         const parsedUrl = new URL(url);
 
         if (parsedUrl.pathname.includes('/static/close')) {
-            if (event) {
-                event.preventDefault();
+            event.preventDefault();
+
+            // Deep-link-initiated leave: after leaveConference() reaches
+            // /static/close, navigate to the new meeting URL instead of
+            // destroying the window or redirecting to the dashboard.
+            //
+            // If the leave-modal was also confirmed in parallel (rare race),
+            // cancel its destroy fallback — the deep-link navigation
+            // supersedes the quit, otherwise the 5s quitFallbackTimer
+            // would destroy the newly-loaded window.
+            if (isDeeplinkPending()) {
+                if (quitting) {
+                    clearTimeout(quitFallbackTimer);
+                    quitting = false;
+                }
+                // Defer out of the will-navigate dispatch — loadURL inside
+                // the navigation handler re-enters Electron's navigation
+                // stack and causes unpredictable ordering.
+                setImmediate(() => {
+                    completeDeeplinkNavigation();
+                });
+
+                return;
             }
 
             // If the user confirmed the leave-modal, destroy instead of
@@ -662,7 +700,7 @@ function createJitsiMeetWindow() {
                 mainWindow.loadURL(closePageUrl);
             });
 
-            return 'redirected';
+            return;
         }
 
         if (parsedUrl.pathname.startsWith('/meet')) {
@@ -918,6 +956,10 @@ function createJitsiMeetWindow() {
 
         // Close the annotation overlay if it is open
         closeOverlay();
+
+        // Tear down any in-flight deep-link state so its timers don't keep
+        // ticking against a destroyed window.
+        cleanupDeeplinkState();
 
         ipcMain.removeListener('retry-load', onRetryLoad);
         ipcMain.removeListener('update-toast-action', onUpdateToast);


### PR DESCRIPTION
## Summary

Fixes three related bugs that hit when a `sonacove://` deep-link arrives while the user is already in a meeting.

Closes #125

### 1. Deep-link URL loaded into the PiP window, not the main window
On Mac always, on Windows when PiP was in pill mode, the new meeting's prejoin rendered inside the tiny floating PiP BrowserWindow instead of the main app window.

**Cause:** `overlay/helpers.js:getMainWindow()` filtered annotation overlays but not the participant PiP panel. Because the PiP is `alwaysOnTop + skipTaskbar`, it became the first `isVisible()` window whenever the main window was minimized/hidden — so `loadURL` hit the PiP.

**Fix:** Added a shared `getParticipantWindow()` accessor to `pip/helpers.js` and taught `overlay/helpers.js:getMainWindow()` to exclude it.

### 2. Clicking "Leave Meeting" in the deep-link modal closed the app
After confirming, `loadURL` tripped jitsi's `beforeunload`, Electron fired `will-prevent-unload`, the **leave-app** modal appeared on top, and its confirm handler `destroy()`'d the window.

**Fix:** `will-prevent-unload` now checks an `takeDeeplinkNavigating()` flag and `event.preventDefault()`s (allowing navigation) instead of showing the quit modal.

### 3. PiP from the old meeting survived the navigation
The renderer's `SCREENSHARE_STOP` IPC cleanup skipped pill mode and could race with page unload, so the PiP window would linger after navigating to the new meeting.

**Fix:** Sequenced clean leave — on deep-link confirm we now send `pip-end-meeting` (same as the leave-modal), wait for jitsi's `leaveConference()` to redirect to `/static/close`, then `completeDeeplinkNavigation()` force-closes the PiP (pill or tile) and `loadURL`s the target. A 5s fallback timer covers unresponsive-renderer cases.

## Changes

- **`app/features/deep-link.js`** — state machine: `pendingDeeplink`, `isDeeplinkPending()`, `completeDeeplinkNavigation()`. On confirm while in meeting: store target, send `pip-end-meeting`, wait for `/static/close` → navigate.
- **`main.js`** — `will-navigate` routes `/static/close` through `completeDeeplinkNavigation()` before the quit-destroy path. `will-prevent-unload` bypasses the quit modal when a deep-link navigation is in flight.
- **`app/features/overlay/helpers.js`** — `getMainWindow()` now also excludes the participant PiP window.
- **`app/features/pip/helpers.js`** — exposes `getParticipantWindow()` for other modules.

## Test plan

### Windows

#### Bug 1 — PiP hijack
- [ ] Start meeting A. Minimize the main window so the PiP pill/tile is visible.
- [ ] In browser, click a `sonacove://...` deep-link for meeting B.
- [ ] Confirm: main window restores and loads B's prejoin. The pill/PiP was NOT the target.

#### Bug 2 — app close
- [ ] In meeting A, click a `sonacove://...` deep-link for meeting B.
- [ ] Deep-link modal ("Meeting in Progress") appears → click **Leave Meeting**.
- [ ] Confirm: app does NOT close. No second "Leave Meeting?" modal.

#### Bug 3 — PiP leftover (tile mode)
- [ ] In meeting A with PiP panel open in tile mode (minimize main window to trigger).
- [ ] Click a `sonacove://...` deep-link for meeting B → confirm "Leave Meeting".
- [ ] Confirm: main window loads B's prejoin, PiP window is gone.

#### Bug 3 — PiP leftover (pill mode)
- [ ] Same as above, but collapse the PiP to a pill before triggering the deep-link.
- [ ] Confirm: pill also disappears on navigation.

#### Regression checks
- [ ] Normal close while in a meeting (click × on titlebar): leave-app modal still appears and "Leave" still destroys the window as before.
- [ ] Deep-link when NOT in a meeting (e.g. app is on dashboard): navigates directly, no modal shown, no "leaving" flow triggered.
- [ ] Cancel the deep-link modal ("Stay"): meeting continues, nothing navigates, PiP stays untouched.
- [ ] Click a deep-link twice quickly: the most recent target wins, only one navigation occurs.

### macOS

Same matrix as Windows. Extra attention to:
- [ ] Bug 1 reproduces on Mac **even without minimizing** (main window just backgrounded). Verify fix handles that case.
- [ ] Deep-link delivery via `open-url` event (macOS-specific) still works — confirm flow fires on first click after app is already running.
- [ ] Dock icon behavior around PiP close is unchanged (no regression from #123).
