### PR TITLE
ci(staging-main): force --draft=false on release edit so it self-heals

### DIFF
--- a/.github/workflows/staging-main.yml
+++ b/.github/workflows/staging-main.yml
@@ -34,13 +34,20 @@ jobs:
             --field ref="refs/tags/${TAG}" \
             --field sha="${SHA}"
 
-          # Create release if it doesn't exist, or update its title
+          # Create release if it doesn't exist, or update it in place.
+          # --draft=false on edit unsticks any release that got flipped to
+          # draft (manual edit via the GitHub UI, or older workflow runs):
+          # the launcher's /releases/tags/<tag> fetch 404s on drafts and
+          # the main-build card stays hidden. --prerelease on edit keeps
+          # that flag stable across title/notes updates.
           if gh release view "${TAG}" --repo "${{ github.repository }}" &>/dev/null; then
             gh release edit "${TAG}" \
               --repo "${{ github.repository }}" \
               --target "${SHA}" \
               --title "${TITLE}" \
-              --notes "Staging build from main branch (commit ${SHORT_SHA})"
+              --notes "Staging build from main branch (commit ${SHORT_SHA})" \
+              --draft=false \
+              --prerelease
           else
             gh release create "${TAG}" \
               --repo "${{ github.repository }}" \


### PR DESCRIPTION
## Summary

The staging launcher's "Main Branch" card was hidden because the \`staging-main\` GitHub release was stuck in **draft** state with assets attached. The launcher's \`fetchMainBuild\` hits \`GET /releases/tags/staging-main\`, and that endpoint returns 404 for drafts — so the card was hidden despite the assets being ready.

### Root cause

The workflow's \`gh release edit\` branch (run on every push to main after the release exists) only updates \`--target\`, \`--title\`, and \`--notes\`. It never touches the \`draft\` flag. So if the release ever got flipped to draft (manual UI edit, older workflow run, failed first-time create, etc.), it stayed stuck forever.

### Fix

Pass \`--draft=false\` and \`--prerelease\` on every \`gh release edit\` — self-healing. The currently-stuck draft was manually published to unblock the launcher immediately; this PR prevents recurrence.

<img width="1188" height="836" alt="image" src="https://github.com/user-attachments/assets/22629d51-838d-4915-b18c-a3fce9d7630e" />


## Changes

- \`.github/workflows/staging-main.yml\` — added \`--draft=false --prerelease\` to the edit branch; added comment explaining why.

## Test plan

- [ ] Merge and push to main. Workflow runs; \`staging-main\` release stays \`draft: false, prerelease: true\` after the run (no regression).
- [ ] Manually flip the release to draft via the GitHub UI. Push any trivial change to main. Confirm the workflow flips it back to published.
- [ ] Open the staging launcher on Windows and Mac. Confirm the "Main Branch" card is visible and downloadable.